### PR TITLE
Added CoinRequest button

### DIFF
--- a/app/src/main/java/com/ravenwallet/presenter/fragments/FragmentRequestAmount.java
+++ b/app/src/main/java/com/ravenwallet/presenter/fragments/FragmentRequestAmount.java
@@ -81,6 +81,7 @@ public class FragmentRequestAmount extends Fragment {
     private BRButton shareButton;
     private Button shareEmail;
     private Button shareTextMessage;
+    private Button shareCoinRequest;
     private boolean shareButtonsShown = true;
     private String selectedIso;
     private Button isoButton;
@@ -124,6 +125,7 @@ public class FragmentRequestAmount extends Fragment {
         shareButton = (BRButton) rootView.findViewById(R.id.share_button);
         shareEmail = (Button) rootView.findViewById(R.id.share_email);
         shareTextMessage = (Button) rootView.findViewById(R.id.share_text);
+        shareCoinRequest = (Button) rootView.findViewById(R.id.share_cr);
         shareButtonsLayout = (BRLinearLayoutWithCaret) rootView.findViewById(R.id.share_buttons_layout);
         close = (ImageButton) rootView.findViewById(R.id.close_button);
         keyboardIndex = signalLayout.indexOfChild(keyboardLayout);
@@ -231,6 +233,21 @@ public class FragmentRequestAmount extends Fragment {
 
                 Uri bitcoinUri = CryptoUriParser.createCryptoUrl(getActivity(), wm, wm.decorateAddress(getActivity(), mReceiveAddress), amount, null, null, null);
                 QRUtils.share("sms:", getActivity(), bitcoinUri.toString());
+            }
+        });
+        shareCoinRequest.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                removeCurrencySelector();
+                if (!BRAnimator.isClickAllowed()) return;
+                showKeyboard(false);
+
+                long satoshiAmount = getAmount();
+                BigDecimal amount = new BigDecimal(satoshiAmount).divide(new BigDecimal(100000000));
+
+                String coinRequestUrl = "https://coinrequest.io/create?coin=ravencoin&address=" + mReceiveAddress + "&amount=" + amount.toString();
+                QRUtils.share("https:", getActivity(), coinRequestUrl);
+
             }
         });
         shareButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/ravenwallet/tools/qrcode/QRUtils.java
+++ b/app/src/main/java/com/ravenwallet/tools/qrcode/QRUtils.java
@@ -167,7 +167,15 @@ public class QRUtils {
             intent.putExtra("exit_on_sent", true);
             app.startActivity(intent);
 
-        } else {
+        }
+        else if(via.equalsIgnoreCase("https:")){
+            if(bitcoinUri.startsWith("https://")){
+                intent.setAction(Intent.ACTION_VIEW);
+                intent.setData(Uri.parse(bitcoinUri));
+                app.startActivity(intent);
+            }
+        }
+        else {
             intent.setAction(Intent.ACTION_SEND);
             intent.setType("image/*");
             intent.putExtra(Intent.EXTRA_SUBJECT, WalletsMaster.getInstance(app).getCurrentWallet(app).getName(app) + " Address");

--- a/app/src/main/res/layout/fragment_receive.xml
+++ b/app/src/main/res/layout/fragment_receive.xml
@@ -250,45 +250,75 @@
                 android:id="@+id/share_buttons_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
+                android:orientation="vertical"
                 android:weightSum="2.0"
                 app:backgroundColor="@color/extra_light_blue_background"
                 app:strokeColor="@color/extra_light_gray"
                 app:withStroke="true">
 
-                <com.ravenwallet.presenter.customviews.BRButton
-                    android:id="@+id/share_email"
+                <LinearLayout
+                    android:id="@+id/share_buttons_wrapper"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginTop="32dp"
-                    android:layout_weight="1.0"
-                    android:paddingBottom="12dp"
-                    android:paddingTop="12dp"
-                    android:text="@string/Receive.emailButton"
-                    android:textColor="@color/light_gray"
-                    android:textSize="14sp"
-                    app:buttonType="1"
-                    app:isBreadButton="true" />
+                    android:orientation="horizontal">
 
-                <com.ravenwallet.presenter.customviews.BRButton
-                    android:id="@+id/share_text"
+                    <com.ravenwallet.presenter.customviews.BRButton
+                        android:id="@+id/share_email"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        android:layout_marginEnd="8dp"
+                        android:layout_marginStart="8dp"
+                        android:layout_marginTop="16dp"
+                        android:layout_weight="1.0"
+                        android:paddingBottom="12dp"
+                        android:paddingTop="12dp"
+                        android:text="@string/Receive.emailButton"
+                        android:textColor="@color/light_gray"
+                        android:textSize="14sp"
+                        app:buttonType="1"
+                        app:isBreadButton="true" />
+
+                    <com.ravenwallet.presenter.customviews.BRButton
+                        android:id="@+id/share_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        android:layout_marginEnd="8dp"
+                        android:layout_marginStart="8dp"
+                        android:layout_marginTop="16dp"
+                        android:layout_weight="1.0"
+                        android:paddingBottom="12dp"
+                        android:paddingTop="12dp"
+                        android:text="@string/Receive.textButton"
+                        android:textColor="@color/light_gray"
+                        android:textSize="14sp"
+                        app:buttonType="1"
+                        app:isBreadButton="true" />
+                </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/cr_button_wrapper"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginTop="32dp"
-                    android:layout_weight="1.0"
-                    android:paddingBottom="12dp"
-                    android:paddingTop="12dp"
-                    android:text="@string/Receive.textButton"
-                    android:textColor="@color/light_gray"
-                    android:textSize="14sp"
-                    app:buttonType="1"
-                    app:isBreadButton="true" />
+                    android:orientation="horizontal">
+
+                    <com.ravenwallet.presenter.customviews.BRButton
+                        android:id="@+id/share_cr"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        android:layout_marginEnd="8dp"
+                        android:layout_marginStart="8dp"
+                        android:layout_marginTop="8dp"
+                        android:layout_weight="1.0"
+                        android:paddingBottom="12dp"
+                        android:paddingTop="12dp"
+                        android:text="@string/Receive.crButton"
+                        android:textColor="@color/light_gray"
+                        android:textSize="14sp"
+                        app:buttonType="1"
+                        app:isBreadButton="true" />
+                </LinearLayout>
 
             </com.ravenwallet.presenter.customviews.BRLinearLayoutWithCaret>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -250,6 +250,8 @@
   <string name="Receive.share">Delen</string>
   <!-- Share via text message (SMS) -->
   <string name="Receive.textButton">Bericht</string>
+  <!-- Share via CoinRequest -->
+  <string name="Receive.crButton">Deel via CoinRequest</string>
   <!-- Receive modal title -->
   <string name="Receive.title">Ontvangen</string>
   <!-- Done button text -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,6 +268,8 @@
     <string name="Receive.share">Share</string>
     <!-- Share via text message (SMS) -->
     <string name="Receive.textButton">Text Message</string>
+    <!-- Share via CoinRequest -->
+    <string name="Receive.crButton">Share via CoinRequest</string>
     <!-- Receive modal title -->
     <string name="Receive.title">Receive</string>
     <!-- Done button text -->


### PR DESCRIPTION
I have added an extra button in the share modal/popup. With this button, the user creates a CoinRequest and can share his request through multiple channels. The receiver(**s**) of this request can pay via multiple wallets without having to fill the address and amount.

Please see this feature request in the IOS version: [https://github.com/RavenProject/ravenwallet-ios/issues/115](https://github.com/RavenProject/ravenwallet-ios/issues/115)

This is the result of my commit:

![button](https://user-images.githubusercontent.com/9481318/61119170-897b7880-a49a-11e9-91e4-aa0b4007039c.PNG)
