### PR TITLE
Allow ClearText so help buttons work on newer Android Devices.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,8 @@
         android:launchMode="singleTask"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:windowSoftInputMode="stateVisible|adjustResize">
+        android:windowSoftInputMode="stateVisible|adjustResize"
+        android:usesCleartextTraffic="true">
 
         <provider
             android:name="android.support.v4.content.FileProvider"


### PR DESCRIPTION
Fixes issue #46 - Android changed to not allow cleartext.  This change allows cleartext on newer flavours of Android.
Note: I tired adding a Network_Security config/XML as recommended. This would limit Cleartext support to only Ravenwallet.org, but it also only allows HTTPS. It appears that Ravenwallet.org does not support HTTPS so the network security path won't work for this.