### PR TITLE
Fixing word list version and seednode peers

### DIFF
--- a/app/src/main/jni/core/BRBIP39WordsEn.h
+++ b/app/src/main/jni/core/BRBIP39WordsEn.h
@@ -1821,7 +1821,7 @@ static const char *BIP39WordsEn[BIP39_WORDLIST_COUNT] = {
     "tent",
     "term",
     "test",
-    "address",
+    "text",
     "thank",
     "that",
     "theme",

--- a/app/src/main/jni/core/BRPeer.c
+++ b/app/src/main/jni/core/BRPeer.c
@@ -58,7 +58,7 @@
 #define MAX_MSG_LENGTH     0x02000000
 #define MAX_GETDATA_HASHES 50000
 #define ENABLED_SERVICES   0ULL  // we don't provide full blocks to remote nodes
-#define PROTOCOL_VERSION   70020
+#define PROTOCOL_VERSION   70025
 #define MIN_PROTO_VERSION  70017 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
 #define LOCAL_HOST         ((UInt128) { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0x00, 0x00, 0x01 })
 #define CONNECT_TIMEOUT    3.0

--- a/app/src/main/jni/core/BRPeer.c
+++ b/app/src/main/jni/core/BRPeer.c
@@ -58,8 +58,8 @@
 #define MAX_MSG_LENGTH     0x02000000
 #define MAX_GETDATA_HASHES 50000
 #define ENABLED_SERVICES   0ULL  // we don't provide full blocks to remote nodes
-#define PROTOCOL_VERSION   70025
-#define MIN_PROTO_VERSION  70020 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
+#define PROTOCOL_VERSION   70020
+#define MIN_PROTO_VERSION  70017 // peers earlier than this protocol version not supported (need v0.9 txFee relay rules)
 #define LOCAL_HOST         ((UInt128) { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0x00, 0x00, 0x01 })
 #define CONNECT_TIMEOUT    3.0
 #define MESSAGE_TIMEOUT    10.0

--- a/app/src/main/jni/core/ChainParams.h
+++ b/app/src/main/jni/core/ChainParams.h
@@ -56,11 +56,11 @@ typedef struct {
 } ChainParams;
 
 static const char *MainNetDNSSeeds[] = {
-        "seed-raven.ravenwallet.com", "seed-raven.ravenwallet.org.", "seed-raven.bitactivate.com.", NULL
+        "seed-raven.ravencoin.com", "seed-raven.ravencoin.org.", "seed-raven.bitactivate.com.", NULL
 };
 
 static const char *TestNetDNSSeeds[] = {
-        "seed-testnet-raven.ravenwallet.com", "seed-testnet-raven.ravenwallet.org.", "seed-testnet-raven.bitactivate.com.",
+        "seed-testnet-raven.ravencoin.com", "seed-testnet-raven.ravencoin.org.", "seed-testnet-raven.bitactivate.com.",
         "52.37.117.13", "52.19.46.153", "34.248.252.173", "34.220.62.90", NULL
 };
 


### PR DESCRIPTION
We found that the BIp39 word list for Android contains the word "Address" twice instead of the correct word "text".  Tron will release a Medium article on how to fix this if someone runs into the issue of not getting wallet recovered correctly.
Also found that the peers for Android were different han IOS.
Also found that the min peer protocol versions were different than IOS.