### PR TITLE
IPFS Gateway Selection UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,11 @@
 
             android:screenOrientation="portrait"/>
         <activity
+            android:name="com.ravenwallet.presenter.activities.settings.IPFSGatewayActivity"
+            android:launchMode="singleTask"
+
+            android:screenOrientation="portrait"/>
+        <activity
             android:name="com.ravenwallet.presenter.activities.settings.AboutActivity"
             android:launchMode="singleTask"
 

--- a/app/src/main/java/com/ravenwallet/presenter/activities/settings/IPFSGatewayActivity.java
+++ b/app/src/main/java/com/ravenwallet/presenter/activities/settings/IPFSGatewayActivity.java
@@ -1,0 +1,197 @@
+package com.ravenwallet.presenter.activities.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Point;
+import android.os.Bundle;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.ravenwallet.R;
+import com.ravenwallet.presenter.activities.util.BRActivity;
+import com.ravenwallet.presenter.customviews.BRDialogView;
+import com.ravenwallet.presenter.entities.IPFSGateway;
+import com.ravenwallet.tools.animation.BRAnimator;
+import com.ravenwallet.tools.animation.BRDialog;
+import com.ravenwallet.tools.manager.BREventManager;
+import com.ravenwallet.tools.manager.BRSharedPrefs;
+import com.ravenwallet.tools.manager.FontManager;
+import com.ravenwallet.tools.util.BRConstants;
+import com.ravenwallet.wallet.WalletsMaster;
+import com.ravenwallet.wallet.abstracts.BaseWalletManager;
+
+import java.util.Currency;
+
+
+public class IPFSGatewayActivity extends BRActivity {
+    private static final String TAG = IPFSGatewayActivity.class.getName();
+    private ListView listView;
+    private GatewayListAdapter adapter;
+    public static boolean appVisible = false;
+    private static IPFSGatewayActivity app;
+    BaseWalletManager mWalletManager;
+
+
+    public static IPFSGatewayActivity getApp() {
+        return app;
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_ipfs_gateway_settings);
+
+        ImageButton faq = findViewById(R.id.faq_button);
+
+        faq.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!BRAnimator.isClickAllowed()) return;
+                BRDialog.showCustomDialog(getApp(),
+                        getString(R.string.Settings_ipfsgateway),
+                        getString(R.string.Settings_ipfsgateway_faq),
+                        getString(R.string.Button_ok), null,
+                        new BRDialogView.BROnClickListener() {
+                            @Override
+                            public void onClick(BRDialogView brDialogView) {
+                                brDialogView.dismissWithAnimation();
+                            }
+                        }, null, null, 0);
+            }
+        });
+
+        mWalletManager = WalletsMaster.getInstance(this).getCurrentWallet(this);
+
+        listView = findViewById(R.id.gateway_list_view);
+        adapter = new GatewayListAdapter(this);
+
+        adapter.add(new IPFSGateway("Cloudflare A", "cf-ipfs.com"));
+        adapter.add(new IPFSGateway("Cloudflare B", "cloudflare-ipfs.com"));
+
+        adapter.add(new IPFSGateway("ipfs.io A", "ipfs.io"));
+        adapter.add(new IPFSGateway("ipfs.io B", "gateway.ipfs.io"));
+
+        adapter.add(new IPFSGateway("DWeb", "dweb.link"));
+        adapter.add(new IPFSGateway("GreyH.at", "ipfs.greyh.at"));
+        adapter.add(new IPFSGateway("infura.io", "ipfs.infura.io"));
+        //Really wanted this one to work, but it times out too much to be reliable :(
+        //adapter.add(new IPFSGateway("Ravenland", "gateway.ravenland.org"));
+
+        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view,
+                                    int position, long id) {
+                IPFSGateway newGateway = adapter.getItem(position);
+                BRSharedPrefs.putPreferredIPFSGateway(IPFSGatewayActivity.this, newGateway.hostname);
+                adapter.notifyDataSetChanged();
+            }
+
+        });
+
+        listView.setAdapter(adapter);
+        adapter.notifyDataSetChanged();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        appVisible = true;
+        app = this;
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        appVisible = false;
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        overridePendingTransition(R.anim.enter_from_left, R.anim.exit_to_right);
+    }
+
+    public class GatewayListAdapter extends ArrayAdapter<IPFSGateway> {
+        public final String TAG = GatewayListAdapter.class.getName();
+
+        private final Context mContext;
+        private final int layoutResourceId;
+        private TextView textViewItem;
+        private final Point displayParameters = new Point();
+
+        public GatewayListAdapter(Context mContext) {
+
+            super(mContext, R.layout.gateway_list_item);
+
+            this.layoutResourceId = R.layout.gateway_list_item;
+            this.mContext = mContext;
+            ((Activity) mContext).getWindowManager().getDefaultDisplay().getSize(displayParameters);
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+
+            final String oldHost = BRSharedPrefs.getPreferredIPFSGateway(mContext);
+            if (convertView == null) {
+                LayoutInflater inflater = ((Activity) mContext).getLayoutInflater();
+                convertView = inflater.inflate(layoutResourceId, parent, false);
+            }
+            textViewItem = convertView.findViewById(R.id.gateway_item_name);
+            FontManager.overrideFonts(textViewItem);
+            IPFSGateway gateway = getItem(position);
+            textViewItem.setText(String.format("%s (%s)", gateway.name, gateway.hostname));
+            ImageView checkMark = convertView.findViewById(R.id.gateway_checkmark);
+
+            if (gateway.hostname.equalsIgnoreCase(oldHost)) {
+                checkMark.setVisibility(View.VISIBLE);
+            } else {
+                checkMark.setVisibility(View.GONE);
+            }
+            normalizeTextView();
+            return convertView;
+        }
+
+        @Override
+        public int getCount() {
+            return super.getCount();
+        }
+
+        @Override
+        public int getItemViewType(int position) {
+            return IGNORE_ITEM_VIEW_TYPE;
+        }
+
+        private boolean isTextSizeAcceptable(TextView textView) {
+            textView.measure(0, 0);
+            int textWidth = textView.getMeasuredWidth();
+            int checkMarkWidth = 76 + 20;
+            return (textWidth <= (displayParameters.x - checkMarkWidth));
+        }
+
+        private boolean normalizeTextView() {
+            int count = 0;
+            while (!isTextSizeAcceptable(textViewItem)) {
+                count++;
+                float textSize = textViewItem.getTextSize();
+                textViewItem.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize - 2);
+                this.notifyDataSetChanged();
+            }
+            return (count > 0);
+        }
+
+    }
+
+
+}

--- a/app/src/main/java/com/ravenwallet/presenter/activities/settings/IPFSGatewayActivity.java
+++ b/app/src/main/java/com/ravenwallet/presenter/activities/settings/IPFSGatewayActivity.java
@@ -77,11 +77,11 @@ public class IPFSGatewayActivity extends BRActivity {
         listView = findViewById(R.id.gateway_list_view);
         adapter = new GatewayListAdapter(this);
 
-        adapter.add(new IPFSGateway("Cloudflare A", "cf-ipfs.com"));
-        adapter.add(new IPFSGateway("Cloudflare B", "cloudflare-ipfs.com"));
-
         adapter.add(new IPFSGateway("ipfs.io A", "ipfs.io"));
         adapter.add(new IPFSGateway("ipfs.io B", "gateway.ipfs.io"));
+
+        adapter.add(new IPFSGateway("Cloudflare A", "cf-ipfs.com"));
+        adapter.add(new IPFSGateway("Cloudflare B", "cloudflare-ipfs.com"));
 
         adapter.add(new IPFSGateway("DWeb", "dweb.link"));
         adapter.add(new IPFSGateway("GreyH.at", "ipfs.greyh.at"));

--- a/app/src/main/java/com/ravenwallet/presenter/activities/settings/SettingsActivity.java
+++ b/app/src/main/java/com/ravenwallet/presenter/activities/settings/SettingsActivity.java
@@ -205,6 +205,15 @@ public class SettingsActivity extends BRActivity {
             }
         }, false));
 
+        items.add(new BRSettingsItem(getString(R.string.Settings_ipfsgateway), BRSharedPrefs.getPreferredIPFSGateway(this), new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(SettingsActivity.this, IPFSGatewayActivity.class);
+                startActivity(intent);
+                overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left);
+            }
+        }, false));
+
         items.add(new BRSettingsItem(getString(R.string.Settings_currencySettings), "", null, true));
 
         items.add(new BRSettingsItem(getString(R.string.Settings_redeem_private_key), "", new View.OnClickListener() {

--- a/app/src/main/java/com/ravenwallet/presenter/entities/IPFSGateway.java
+++ b/app/src/main/java/com/ravenwallet/presenter/entities/IPFSGateway.java
@@ -1,0 +1,49 @@
+package com.ravenwallet.presenter.entities;
+
+import java.io.Serializable;
+
+
+/**
+ * RavenWallet
+ * <p/>
+ * Created by Mihail Gutan <mihail@breadwallet.com> on 8/18/15.
+ * Copyright (c) 2016 breadwallet LLC
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+public class IPFSGateway implements Serializable {
+    public static final String TAG = IPFSGateway.class.getName();
+
+    public String hostname;//the gateway's hostname, ie: ipfs.io or cloudflare-ipfs.com
+    public String name;//the gateway's display name
+
+    public IPFSGateway(String name, String hostname) {
+        this.hostname = hostname;
+        this.name = name;
+    }
+
+    public IPFSGateway() {
+    }
+
+    @Override
+    public String toString() {
+        return "host: " + hostname + " name: " + name;
+    }
+}

--- a/app/src/main/java/com/ravenwallet/presenter/fragments/FragmentAssetMenu.java
+++ b/app/src/main/java/com/ravenwallet/presenter/fragments/FragmentAssetMenu.java
@@ -27,6 +27,7 @@ import com.ravenwallet.presenter.interfaces.WalletManagerListener;
 import com.ravenwallet.tools.animation.BRAnimator;
 import com.ravenwallet.tools.animation.BRDialog;
 import com.ravenwallet.tools.manager.BRSharedPrefs;
+import com.ravenwallet.tools.util.Utils;
 import com.ravenwallet.wallet.WalletsMaster;
 import com.ravenwallet.wallet.abstracts.BaseWalletManager;
 import com.ravenwallet.wallet.RvnWalletManager;
@@ -50,7 +51,6 @@ public class FragmentAssetMenu extends Fragment implements BurnFragmentListener,
     private BRButton getDataButton;
     private Asset mAsset;
     private final static String EXTRAS_ASSET_KEY = "extras.asset.key";
-    private String BASE_IPFS_URL = "http://ipfs.io/ipfs/";
 
     public static FragmentAssetMenu newInstance(Asset asset) {
         FragmentAssetMenu fragment = new FragmentAssetMenu();
@@ -203,7 +203,7 @@ public class FragmentAssetMenu extends Fragment implements BurnFragmentListener,
                 String IPFSHash = mAsset.getIpfsHash();
                 if (!TextUtils.isEmpty(IPFSHash)) {
                     closeMe();
-                    String URL = BASE_IPFS_URL.concat(IPFSHash);
+                    String URL = Utils.getIpfsUrlFromHash(getContext(), IPFSHash);
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(URL)));
                     //BRAnimator.showIPFSFragment(getActivity(), IPFSHash);
                 }

--- a/app/src/main/java/com/ravenwallet/presenter/fragments/FragmentIPFS.java
+++ b/app/src/main/java/com/ravenwallet/presenter/fragments/FragmentIPFS.java
@@ -53,7 +53,6 @@ public class FragmentIPFS extends Fragment {
     public LinearLayout backgroundLayout;
     public CardView signalLayout;
     private WebView webView;
-    private String BASE_IPFS_URL = "http://ipfs.io/ipfs/";
 
     public static String IPFS_HASH_KEY_EXTRAS = "IPFS.hash.key.extras";
 
@@ -84,7 +83,7 @@ public class FragmentIPFS extends Fragment {
             getActivity().getFragmentManager().popBackStack();
             return null;
         } else {
-            String URL = BASE_IPFS_URL.concat(IPFSHash);
+            String URL = Utils.getIpfsUrlFromHash(getContext(), IPFSHash);
 
             WebSettings webSettings = webView.getSettings();
 

--- a/app/src/main/java/com/ravenwallet/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/com/ravenwallet/tools/manager/BRSharedPrefs.java
@@ -95,6 +95,18 @@ public class BRSharedPrefs {
 
     }
 
+    public static String getPreferredIPFSGateway(Context context) {
+        SharedPreferences settingsToGet = context.getSharedPreferences(PREFS_NAME, 0);
+        return settingsToGet.getString("ipfsGateway", null);
+    }
+
+    public static void putPreferredIPFSGateway(Context context, String gateway) {
+        SharedPreferences settings = context.getSharedPreferences(PREFS_NAME, 0);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putString("ipfsGateway", gateway);
+        editor.apply();
+    }
+
     public static boolean getExpertMode(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getBoolean("expertMode", false);

--- a/app/src/main/java/com/ravenwallet/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/com/ravenwallet/tools/manager/BRSharedPrefs.java
@@ -97,7 +97,7 @@ public class BRSharedPrefs {
 
     public static String getPreferredIPFSGateway(Context context) {
         SharedPreferences settingsToGet = context.getSharedPreferences(PREFS_NAME, 0);
-        return settingsToGet.getString("ipfsGateway", null);
+        return settingsToGet.getString("ipfsGateway", BRConstants.IPFS_DEFAULT_HOST);
     }
 
     public static void putPreferredIPFSGateway(Context context, String gateway) {

--- a/app/src/main/java/com/ravenwallet/tools/util/BRConstants.java
+++ b/app/src/main/java/com/ravenwallet/tools/util/BRConstants.java
@@ -136,6 +136,8 @@ public class BRConstants {
     public static final String IP_REGEX = "^\\d{1,3}(\\.(\\d{1,3}(\\.(\\d{1,3}(\\.(\\d{1,3})?)?)?)?)?)?";
     public static final String PRIVACY_URL = "https://ravencoin.org/mobilewallet/support/privacy.html";
 
+    public static final String IPFS_URL_FORMAT = "https://%s/ipfs/%s";
+
     public static final List<String> STR_ISSUE_ASSET_BURN_ADDESSES =
             Lists.newArrayList("RXissueAssetXXXXXXXXXXXXXXXXXhhZGt",
                     "n1issueAssetXXXXXXXXXXXXXXXXWdnemQ");

--- a/app/src/main/java/com/ravenwallet/tools/util/BRConstants.java
+++ b/app/src/main/java/com/ravenwallet/tools/util/BRConstants.java
@@ -137,6 +137,8 @@ public class BRConstants {
     public static final String PRIVACY_URL = "https://ravencoin.org/mobilewallet/support/privacy.html";
 
     public static final String IPFS_URL_FORMAT = "https://%s/ipfs/%s";
+    //NOTE: Additional hosts are defined in IPFSGatewayActivity.java
+    public static final String IPFS_DEFAULT_HOST = "ipfs.io";
 
     public static final List<String> STR_ISSUE_ASSET_BURN_ADDESSES =
             Lists.newArrayList("RXissueAssetXXXXXXXXXXXXXXXXXhhZGt",

--- a/app/src/main/java/com/ravenwallet/tools/util/Utils.java
+++ b/app/src/main/java/com/ravenwallet/tools/util/Utils.java
@@ -18,6 +18,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
 import com.ravenwallet.presenter.activities.intro.IntroActivity;
+import com.ravenwallet.tools.manager.BRSharedPrefs;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -223,5 +224,10 @@ public class Utils {
             return splitResult[1];
         }
         return null;
+    }
+
+    public static String getIpfsUrlFromHash(Context app, String hash) {
+        //TODO: Hash Validation?
+        return String.format(BRConstants.IPFS_URL_FORMAT, BRSharedPrefs.getPreferredIPFSGateway(app), hash);
     }
 }

--- a/app/src/main/res/layout/activity_ipfs_gateway_settings.xml
+++ b/app/src/main/res/layout/activity_ipfs_gateway_settings.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/extra_light_blue_background"
+    tools:context="com.ravenwallet.presenter.activities.SetPinActivity">
+
+    <com.ravenwallet.presenter.customviews.BRText
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="32dp"
+        android:text="@string/Settings.ipfsgateway"
+        android:textColor="@color/almost_black"
+        android:textSize="@dimen/header"
+        app:customTFont="CircularPro-Bold.otf"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/faq_button"
+        android:layout_width="@dimen/faq_dimen"
+        android:layout_height="@dimen/faq_dimen"
+        android:layout_marginBottom="0dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="0dp"
+        android:background="@drawable/faq_question_black"
+        app:layout_constraintBottom_toBottomOf="@+id/title"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/title" />
+
+    <ListView
+        android:id="@+id/gateway_list_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginLeft="0dp"
+        android:layout_marginRight="0dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title"
+        app:layout_constraintVertical_bias="0.0" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/gateway_list_item.xml
+++ b/app/src/main/res/layout/gateway_list_item.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/white"
+    android:orientation="vertical">
+
+    <com.ravenwallet.presenter.customviews.BRText
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/gateway_item_name"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:filterTouchesWhenObscured="true"
+        android:gravity="center_vertical"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:paddingStart="16dp"
+        android:text=""
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textColor="@color/dark_gray"
+        android:textSize="@dimen/sub_header"
+        app:customTFont="CircularPro-Medium.otf"/>
+
+    <ImageView
+        android:id="@+id/gateway_checkmark"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="10dp"
+        android:background="@drawable/ic_check_mark_blue"
+        android:filterTouchesWhenObscured="true"
+        android:visibility="gone"/>
+
+    <com.ravenwallet.presenter.customviews.BRText
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/gateway_item_hostname"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:layout_toLeftOf="@id/gateway_checkmark"
+        android:filterTouchesWhenObscured="true"
+        android:gravity="center_vertical"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:paddingStart="16dp"
+        android:text=""
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textColor="@color/dark_gray"
+        android:textSize="@dimen/sub_header"
+        app:customTFont="CircularPro-Medium.otf"/>
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -397,6 +397,8 @@
     <!-- i.e. the currency which will be displayed -->
     <string name="Settings.currency">Display Currency</string>
     <string name="Settings.currencySettings">Currency Settings</string>
+    <string name="Settings.ipfsgateway">IPFS Gateway</string>
+    <string name="Settings.ipfsgateway_faq">Attachments on assets, and other resources, are uploaded to the IPFS distributed network.\n\nThis option selects which centralized web-host the application should use, when displaying IPFS content.</string>
     <string name="Settings.rescan.blockchain">Sync Blockchain</string>
     <string name="Settings.redeem.private.key">Redeem Wallet / Private Key</string>
     <string name="Settings.other">Other</string>


### PR DESCRIPTION
This PR adds an option in the settings screen, allowing the user to manually choose which gateway they would like to use for IPFS content.

There are 7 gateway choices available, with more being simple to add.

- ipfs.io A (ipfs.io) *Default
- ipfs.io B (gateway.ipfs.io)
- Cloudflare A (cf-ipfs.com)
- Cloudflare B (cloudflare-ipfs.com)
- DWeb (dweb.link)
- GreyH.at (ipfs.greyh.at)
- infura.io (ipfs.infura.io)

Raven Address: **RYW4MmiT2jDdZPa499VQiPANZdStxGt8y5**

Screenshots:
![ipfs_all_screenshots](https://user-images.githubusercontent.com/793454/113738313-cb1b7080-96cc-11eb-853d-4677889c0c27.png)